### PR TITLE
Realtime priority on Windows

### DIFF
--- a/src/core/xt/xt/private/PlatformWin32.cpp
+++ b/src/core/xt/xt/private/PlatformWin32.cpp
@@ -5,9 +5,15 @@
 void XtPlatform
 ::EndThread() { CoUninitialize(); }
 void XtPlatform::
-RevertThreadPriority(int32_t policy, int32_t previous) { }
+RevertThreadPriority(int32_t policy, int32_t previous) {
+	SetPriorityClass(GetCurrentProcess(), NORMAL_PRIORITY_CLASS);
+	SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_NORMAL);
+}
 void XtPlatform::
-RaiseThreadPriority(int32_t* policy, int32_t* previous) { }
+RaiseThreadPriority(int32_t* policy, int32_t* previous) {
+	SetPriorityClass(GetCurrentProcess(), REALTIME_PRIORITY_CLASS);
+	SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL);
+}
 void 
 XtPlatform::BeginThread() 
 { XT_ASSERT_COM(CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED)); }


### PR DESCRIPTION
When the java application on Windows is out of focus, the audio starts crackling slightly. This can be pushed to the extreme when 
 running a light CPU benchmark, rendering the audio completely unusable due to constant audio stutters.

I'm not entirely sure if this is *the* way to change thread priorities on Windows, however this **completely** removes all audio stutters even on very high CPU usage.